### PR TITLE
feat(core): support custom app packages via config

### DIFF
--- a/packages/core/src/actions/handler.ts
+++ b/packages/core/src/actions/handler.ts
@@ -92,7 +92,8 @@ export class ActionHandler {
    * Execute launch action.
    */
   private async executeLaunchAction(action: LaunchAction): Promise<ActionResult> {
-    const success = await launchApp(action.app, this.deviceId)
+    const config = this.context.getConfig()
+    const success = await launchApp(action.app, this.deviceId, 1.0, config.customApps)
 
     if (!success) {
       return {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -149,7 +149,7 @@ export class PhoneAgent {
       10,
       this.agentConfig.screenshotQuality,
     )
-    const currentApp = await getCurrentApp(this.agentConfig.deviceId)
+    const currentApp = await getCurrentApp(this.agentConfig.deviceId, this.agentConfig.customApps)
 
     // Build messages
     if (isFirst) {

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -3,6 +3,12 @@ export interface AgentConfigType {
   lang: 'cn' | 'en'
   deviceId?: string
   systemPrompt?: string
+  /**
+   * Custom app name to package name mapping.
+   * These will override the built-in APP_PACKAGES.
+   * @example { '自定义应用': 'com.example.app' }
+   */
+  customApps?: Record<string, string>
   // ModelConfigType
   baseUrl: string
   apiKey: string


### PR DESCRIPTION
- Add `customApps` field to AgentConfigType for custom app name to package mapping
- Implement `mergeAppPackages` utility to merge custom apps with built-in APP_PACKAGES
- Update `launchApp` and `getCurrentApp` to accept and prioritize custom apps
- Pass customApps through ActionHandler and Agent execution flow
- Maintain backward compatibility: defaults to APP_PACKAGES when no custom apps provided

This enables users to extend or override the static app list by providing their own app mappings in the configuration, improving flexibility without breaking existing behavior.